### PR TITLE
Docs/license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Issakha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Issakha
+Copyright (c) 2025 Formation DevOps
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Nous encourageons les contributions ! Voici comment tu peux aider :
 ---
 
 ## 📜 **Licence**
-Ce projet est sous licence **MIT**. Tu peux l'utiliser, le modifier et le redistribuer librement.
+Ce projet est sous licence [**MIT**](https://github.com/cisse410/Formation-Devops/blob/feat/license/LICENSE.md). Tu peux l'utiliser, le modifier et le redistribuer librement.
 
 ---
 


### PR DESCRIPTION
Le constat est que sur le README, c'est mentionné que le projet est sous licence **MIT**  et cette licence n'existait pas. C'est ce qui m'a amené à ajouter la licence et la référencée par un lien au niveau du README